### PR TITLE
 clean the pipeline storage

### DIFF
--- a/learn2rag/ui/__init__.py
+++ b/learn2rag/ui/__init__.py
@@ -208,6 +208,21 @@ def create_app(config: dict[str, Any]={}) -> Flask:
         app.logger.exception(e)
         app.logger.warning('Ollama is already running or failed to start')
 
+    def remove_pipeline_storage_directory(storage_path: Path) -> bool:
+        try:
+            storage_path = expand_path(storage_path)
+            shutil.rmtree(storage_path)
+            flash(pgettext('flash', 'Directory removed: %(path)s', path=storage_path))
+        except FileNotFoundError:
+            # storage directory may be not created yet
+            app.logger.info('Directory was not removed since it does not exist: %s', storage_path)
+            pass
+        except Exception as e:
+            app.logger.error('Failed to remove directory: %s, %s', storage_path, e)
+            flash(pgettext('flash', 'Failed to remove directory: %(path)s: %(message)s', path=storage_path, message=e), 'error')
+            return False
+        return True
+
     @app.get('/')
     def start() -> 'str | werkzeug.wrappers.response.Response':
         pipelines = learn2rag.data.get_all(app.instance_path, 'pipelines')
@@ -419,17 +434,10 @@ def create_app(config: dict[str, Any]={}) -> Flask:
         pipeline = learn2rag.data.get_entry(app.instance_path, 'pipelines', name)
         if pipeline is None:
             flash(pgettext('flash', 'The requested pipeline is not found'), 'error')
+        elif request.form['action'] == 'clean':
+            remove_pipeline_storage_directory(pipeline['storage_path'])
         elif request.form['action'] == 'delete':
-            ok = True
-            try:
-                storage_path = expand_path(pipeline['storage_path'])
-                shutil.rmtree(storage_path)
-            except FileNotFoundError:
-                pass
-            except Exception as e:
-                app.logger.error('Failed to remove directory: %s, %s', storage_path, e)
-                flash(pgettext('flash', 'Failed to remove directory: %(path)s', path=storage_path), 'error')
-                ok = False
+            ok = remove_pipeline_storage_directory(pipeline['storage_path'])
             if ok:
                 learn2rag.data.delete_entry(app.instance_path, 'pipelines', name)
                 flash(pgettext('flash', 'Removed pipeline: %(label)s', label=pipeline['label']))
@@ -443,16 +451,6 @@ def create_app(config: dict[str, Any]={}) -> Flask:
                 app.logger.exception(e)
                 app.logger.error('Could not stop the pipeline')
                 flash(pgettext('flash', 'Could not stop the pipeline: %(message)s', message=e), 'error')
-        elif request.form['action'] == 'clean':
-            try:
-                storage_path = expand_path(pipeline['storage_path'])
-                shutil.rmtree(storage_path)
-                flash(pgettext('flash', 'Successfully clean the pipeline storage: '), 'success')
-            except FileNotFoundError:
-                pass
-            except Exception as e:
-                app.logger.error('Failed to remove directory: %s, %s', storage_path, e)
-                flash(pgettext('flash', 'Could not clean the pipeline storage: %(message)s', message=e), 'error')
         return redirect(url_for('pipelines_list'))
 
     @app.get('/pipelines/<name>/logs/<file>')

--- a/learn2rag/ui/__init__.py
+++ b/learn2rag/ui/__init__.py
@@ -443,6 +443,16 @@ def create_app(config: dict[str, Any]={}) -> Flask:
                 app.logger.exception(e)
                 app.logger.error('Could not stop the pipeline')
                 flash(pgettext('flash', 'Could not stop the pipeline: %(message)s', message=e), 'error')
+        elif request.form['action'] == 'clean':
+            try:
+                storage_path = expand_path(pipeline['storage_path'])
+                shutil.rmtree(storage_path)
+                flash(pgettext('flash', 'Successfully clean the pipeline storage: '), 'success')
+            except FileNotFoundError:
+                pass
+            except Exception as e:
+                app.logger.error('Failed to remove directory: %s, %s', storage_path, e)
+                flash(pgettext('flash', 'Could not clean the pipeline storage: %(message)s', message=e), 'error')
         return redirect(url_for('pipelines_list'))
 
     @app.get('/pipelines/<name>/logs/<file>')

--- a/learn2rag/ui/templates/_pipelines_list_table.html
+++ b/learn2rag/ui/templates/_pipelines_list_table.html
@@ -102,6 +102,15 @@
                       </button>
                     </form>
                   </li>
+                  <li><hr class="dropdown-divider"></li>
+                  <li>
+                    <form method="POST" action="{{ url_for('pipeline_action', name=name) }}" hx-boost="true" hx-confirm="{{gettext('Are you sure you want to clean this pipeline storage: %(label)s?', label=pipeline.label)}}">
+                      <input type="hidden" name="action" value="clean"/>
+                      <button type="submit" class="dropdown-item text-bg-danger">
+                        {{pgettext('button', 'Clean storage')}}
+                      </button>
+                    </form>
+                  </li>
                 </ul>
               </div>
               {% endif %}

--- a/learn2rag/ui/templates/_pipelines_list_table.html
+++ b/learn2rag/ui/templates/_pipelines_list_table.html
@@ -95,19 +95,18 @@
                   </li>
                   <li><hr class="dropdown-divider"></li>
                   <li>
-                    <form method="POST" action="{{ url_for('pipeline_action', name=name) }}" hx-boost="true" hx-confirm="{{gettext('Are you sure you want to remove this pipeline configuration and all stored data: %(label)s?', label=pipeline.label)}}">
-                      <input type="hidden" name="action" value="delete"/>
+                    <form method="POST" action="{{ url_for('pipeline_action', name=name) }}" hx-boost="true" hx-confirm="{{gettext('Are you sure you want to remove all data stored for this pipeline: %(label)s?', label=pipeline.label)}}">
+                      <input type="hidden" name="action" value="clean"/>
                       <button type="submit" class="dropdown-item text-bg-danger">
-                        {{pgettext('button', 'Remove')}}
+                        {{pgettext('button', 'Remove the stored data')}}
                       </button>
                     </form>
                   </li>
-                  <li><hr class="dropdown-divider"></li>
                   <li>
-                    <form method="POST" action="{{ url_for('pipeline_action', name=name) }}" hx-boost="true" hx-confirm="{{gettext('Are you sure you want to clean this pipeline storage: %(label)s?', label=pipeline.label)}}">
-                      <input type="hidden" name="action" value="clean"/>
+                    <form method="POST" action="{{ url_for('pipeline_action', name=name) }}" hx-boost="true" hx-confirm="{{gettext('Are you sure you want to remove this pipeline configuration and all its stored data: %(label)s?', label=pipeline.label)}}">
+                      <input type="hidden" name="action" value="delete"/>
                       <button type="submit" class="dropdown-item text-bg-danger">
-                        {{pgettext('button', 'Clean storage')}}
+                        {{pgettext('button', 'Remove the stored data and the pipeline')}}
                       </button>
                     </form>
                   </li>


### PR DESCRIPTION
it is cleaning the storage (directory ) , but I see an error when trying to run RAG
which is not related to these changes 
```
v0.6.15 - building the best AI user interface.

https://github.com/open-webui/open-webui

ERROR [open_webui.retrieval.utils] Cannot determine model snapshot path: Cannot find an appropriate cached snapshot folder for the specified revision on the local disk and outgoing traffic has been disabled. To enable repo look-ups and downloads online, pass 'local_files_only=False' as input.
Traceback (most recent call last):
  File "/home/farshad/projects/l2r/configurator/services/open-webui/.venv/lib/python3.11/site-packages/open_webui/retrieval/utils.py", line 650, in get_model_path
    model_repo_path = snapshot_download(**snapshot_kwargs)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/farshad/projects/l2r/configurator/services/open-webui/.venv/lib/python3.11/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/home/farshad/projects/l2r/configurator/services/open-webui/.venv/lib/python3.11/site-packages/huggingface_hub/_snapshot_download.py", line 230, in snapshot_download
    raise LocalEntryNotFoundError(
huggingface_hub.errors.LocalEntryNotFoundError: Cannot find an appropriate cached snapshot folder for the specified revision on the local disk and outgoing traffic has been disabled. To enable repo look-ups and downloads online, pass 'local_files_only=False' as input.
WARNI [sentence_transformers.SentenceTransformer] No sentence-transformers model found with name sentence-transformers/all-MiniLM-L6-v2. Creating a new one with mean pooling.

```
before merge we should make sure what is the root of thie error 